### PR TITLE
hex encode performance

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,10 @@
 require "bundler/gem_tasks"
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.test_files = FileList['test/**/*_test.rb']
+  t.verbose = true
+end
+
+task :default => :test

--- a/camo.gemspec
+++ b/camo.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "minitest"
 end

--- a/lib/camo.rb
+++ b/lib/camo.rb
@@ -5,7 +5,7 @@ module Camo
 
   def camo(image_url)
     hexdigest = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha1"), ENV["CAMO_KEY"], image_url)
-    encoded_image_url = image_url.to_enum(:each_byte).map{|byte| "%02x" % byte }.join
+    encoded_image_url = image_url.unpack('H*').first
     "#{ENV["CAMO_HOST"]}/#{hexdigest}/#{encoded_image_url}"
   end
 

--- a/test/camo_test.rb
+++ b/test/camo_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class CamoTest < Minitest::Test
+  def test_view_helper
+    expected = 'http://camo.example.com/b82e650cfe20239b66f7165e54c3b9036d722aef/68747470733a2f2f7777772e6578616d706c652e636f6d2f706174682f746f2f696d6167652e706e67'
+    assert_equal expected, TestContainer.camo('https://www.example.com/path/to/image.png')
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,10 @@
+require 'bundler/setup'
+require 'camo'
+require 'minitest/autorun'
+
+ENV['CAMO_HOST'] ||= 'http://camo.example.com'
+ENV['CAMO_KEY']  ||= '461fbf74af826c3a1020'
+
+class TestContainer
+  extend Camo
+end


### PR DESCRIPTION
ruby's benchmark with 100_000 iterations report some  performance
improvement over iterating over each byte.

https://gist.github.com/glaszig/9d1975b1821a799c5db5957c4cff1539

```
                    user     system      total        real
interpolation   4.510000   0.010000   4.520000 (  4.534379)
String#unpack   0.110000   0.000000   0.110000 (  0.110003)
```

also adds a test case for me to prove i don't mess around ;)
